### PR TITLE
bugfix: Shuffle both sets of cards

### DIFF
--- a/js/stores/TileStore.js
+++ b/js/stores/TileStore.js
@@ -12,11 +12,13 @@ var _tiles = [];
 
 function generateTiles() {
     var images = [];
+    var images2 = [];
     for (var i = 1; i < 9; i++) {
         images.push("images/" + i + ".jpg");
     }
     images = _.shuffle(images);
-    images = images.concat(images);
+	images2 = _.shuffle(images);
+    images = images.concat(images2);
     for (var i = 0; i < images.length; i++) {
         _tiles.push({
             image: images[i],


### PR DESCRIPTION
Shuffle both sets of cards - before this commit, both sets we're always in the same order so very easy to solve.